### PR TITLE
фиксы определения измененных файлов

### DIFF
--- a/app/src/main/java/com/example/vkstorage/common/util/Utils.kt
+++ b/app/src/main/java/com/example/vkstorage/common/util/Utils.kt
@@ -2,13 +2,14 @@ package com.example.vkstorage.common.util
 
 import com.example.vkstorage.R
 import com.example.vkstorage.domain.model.MyFile
+import java.io.BufferedInputStream
 import java.io.File
-import java.io.FileInputStream
 import java.security.MessageDigest
+import java.util.*
 
 fun calculateHash(file: File): String {
     val md = MessageDigest.getInstance("SHA-256")
-    val fis = FileInputStream(file)
+    val fis = BufferedInputStream(file.inputStream())
     val buffer = ByteArray(8192)
     var read: Int
     while (fis.read(buffer).also { read = it } != -1) {
@@ -20,14 +21,16 @@ fun calculateHash(file: File): String {
 }
 
 fun getAllFiles(file: File): List<File> {
-    if (file.listFiles().isNullOrEmpty()) return emptyList()
-    val files = buildList<File> {
-        for (path in file.listFiles()!!) {
-            if (path.isDirectory) {
-                addAll(getAllFiles(path))
-            } else {
-                add(path)
-            }
+    val stack = Stack<File>()
+    val files = mutableListOf<File>()
+
+    stack.push(file)
+    while (stack.isNotEmpty()) {
+        val currentFile = stack.pop()
+        if (currentFile.isDirectory) {
+            currentFile.listFiles()?.forEach { stack.push(it) }
+        } else {
+            files.add(currentFile)
         }
     }
     return files

--- a/app/src/main/java/com/example/vkstorage/data/dataSource/FileHashDatabase.kt
+++ b/app/src/main/java/com/example/vkstorage/data/dataSource/FileHashDatabase.kt
@@ -6,7 +6,7 @@ import com.example.vkstorage.domain.model.FileHash
 
 @Database(
     entities = [FileHash::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 abstract class FileHashDatabase : RoomDatabase() {

--- a/app/src/main/java/com/example/vkstorage/domain/model/FileHash.kt
+++ b/app/src/main/java/com/example/vkstorage/domain/model/FileHash.kt
@@ -7,6 +7,5 @@ import androidx.room.PrimaryKey
 data class FileHash(
     val hash: String,
     @PrimaryKey
-    val path: String,
-    val isModifiedSinceLastLaunch: Boolean = false
+    val path: String
 )


### PR DESCRIPTION
- функция, формирующая список всех файлов, теперь работает через стэк, а не через рекурсию
- в SaveAllFilesHashes юз кейсе убраны ненужные проверки, а сохранненые файлы хранятся в мапе, а не в списке. Также, сначала выводится список измененных файлов, а уже потом происходит сохранение файлов в бд
- убрано поле isModifiedSinceLastLaunch из FileHash
- в функции calculateHash FileInputStream заменен на BufferedInputStream